### PR TITLE
Set correct cmdParams in child_process example

### DIFF
--- a/manuscript/injections.md
+++ b/manuscript/injections.md
@@ -316,7 +316,7 @@ var child_process = require('child_process');
 
 function listPath(directory) {
   var cmd = "ls";
-  var cmdParams = ['ls'];
+  var cmdParams = ['-alh'];
   cmdParams.push(directory);
   child_process.execFile(cmd, cmdParams, function(err, data) {
     console.log(data);


### PR DESCRIPTION
Per our discussion on twitter, the chid_process example had the wrong cmdParams.

I tested this locally and found it needed the preceeding dash which I didn't include in my tweet. It is in this pull request and runs fine.